### PR TITLE
Auto discover credentials for IAM Roles when using production.

### DIFF
--- a/cc_dynamodb/__init__.py
+++ b/cc_dynamodb/__init__.py
@@ -149,7 +149,7 @@ def get_table_index(table_name, index_name):
 def get_connection(discover_credentials=False):
     """Returns a DynamoDBConnection even if credentials are invalid."""
     if discover_credentials:
-        return boto.get_dynamodb()
+        return boto.connect_dynamodb()
 
     config = get_config()
 


### PR DESCRIPTION
Boto will automatically find the credentials in the instance metadata for you and use them as long as no other credentials are found in environment variables or in a boto config file. 

boto.get_dynamodb()  # Defaults to Layer2 interface
